### PR TITLE
Fix nullptr exception in vectorInfo

### DIFF
--- a/cdm/src/main/java/uk/ac/rdg/resc/edal/dataset/cdm/CdmDatasetFactory.java
+++ b/cdm/src/main/java/uk/ac/rdg/resc/edal/dataset/cdm/CdmDatasetFactory.java
@@ -305,6 +305,9 @@ public abstract class CdmDatasetFactory extends DatasetFactory {
                     String stdName = metadata.getParameter().getStandardName();
                     if (stdName != null && stdName.contains(stdRoot)) {
                         IdComponentEastNorth vectorInfo = determineVectorIdAndComponent(stdName);
+                        if (vectorInfo == null) {
+                          continue;
+                        }
                         if(vectorInfo.isX) {
                             xVars.add(varId);
                             xVarIndexedTrueEN.add(vectorInfo.isEastNorth);


### PR DESCRIPTION
We came across a nullptr exception in `vectorInfo` in https://github.com/Unidata/tds/issues/268.

The aggregation in that example lead to a `stdRoot == sea_water_velocity`. There was also variable with the attribute `w:standard_name = "upward_sea_water_velocity" ;`. For that variable name the `determineVectorIdAndComponent` returns null.

I have manually tested this fix with TDS, and made a PR in the reading edal-java here: https://github.com/Reading-eScience-Centre/edal-java/pull/146. If you want to wait for that PR to be approved first that is also fine with me.