### PR TITLE
fix WMS aggregation issue

### DIFF
--- a/cdm/src/main/java/uk/ac/rdg/resc/edal/dataset/cdm/CdmGridDataSource.java
+++ b/cdm/src/main/java/uk/ac/rdg/resc/edal/dataset/cdm/CdmGridDataSource.java
@@ -234,20 +234,10 @@ final class CdmGridDataSource implements GridDataSource {
                 /*
                  * See definition of syncObj for explanation of synchronization
                  */
-                if (origVar == null) {
-                    synchronized (syncObj) {
-                        /* We read from the enhanced variable */
-                        arr = var.read(rangesList.getRanges());
-                    }
-                } else {
-                    synchronized (syncObj) {
-                        /*
-                         * We read from the original variable to avoid enhancing data values that we
-                         * won't use
-                         */
-                        arr = origVar.read(rangesList.getRanges());
-                    }
-                }
+              synchronized (syncObj) {
+                /* We read from the enhanced variable */
+                arr = var.read(rangesList.getRanges());
+              }
             } catch (InvalidRangeException ire) {
                 log.error("Problem reading data - invalid range:\n" + "x: " + xmin + " -> " + xmax + "y: " + ymin
                         + " -> " + ymax + "z: " + zmin + " -> " + zmax + "t: " + tmin + " -> " + tmax);


### PR DESCRIPTION
When an aggregation has some variables that don't depend on the aggregation dimension, those variables have `origVar != null`. However, the `origVar` should not be used to read the data for that variable in this case, because the proxyReader is not the aggregation version (`aggProxyReader`). It has an iosp with a null `raf`, because this is based on looking up the `urlPath` (which does not have a dataset root so doesn't point to a file) instead of the using the aggregation `location`. I don't think this `origVar` should be used to read the variable data. This is not done in other services such as openDap.

I am adding a test for this fix to the TDS repo (https://github.com/Unidata/tds/pull/309)