### PR TITLE
Remove logged error

### DIFF
--- a/graphics/src/main/java/uk/ac/rdg/resc/edal/graphics/utils/SldTemplateStyleCatalogue.java
+++ b/graphics/src/main/java/uk/ac/rdg/resc/edal/graphics/utils/SldTemplateStyleCatalogue.java
@@ -392,8 +392,6 @@ public class SldTemplateStyleCatalogue implements StyleCatalogue {
             velocityEngine.addProperty(RuntimeConstants.FILE_RESOURCE_LOADER_PATH,
                     stylesDir.getAbsolutePath());
         } else {
-            log.error("User tried to add a styles directory which was not a directory: "
-                    + stylesDir.getAbsolutePath());
             throw new FileNotFoundException("The path " + stylesDir.getAbsolutePath()
                     + " is not a directory");
         }


### PR DESCRIPTION
Remove error level log message for a style directory not found. Instead let caller decide what to do with thrown exception. This makes behavior the same as for loading a palette directory.