### PR TITLE
Update jakarta servlet and xml bind

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>org.apache.sis.core</groupId>
             <artifactId>sis-referencing</artifactId>
-            <version>1.0</version>
+            <version>1.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.sis.non-free</groupId>
             <artifactId>sis-epsg</artifactId>
-            <version>1.0</version>
+            <version>1.4</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/common/src/main/java/uk/ac/rdg/resc/edal/util/GISUtils.java
+++ b/common/src/main/java/uk/ac/rdg/resc/edal/util/GISUtils.java
@@ -46,7 +46,7 @@ import javax.naming.Name;
 import javax.naming.spi.ObjectFactory;
 
 import org.apache.sis.geometry.DirectPosition2D;
-import org.apache.sis.internal.metadata.sql.Initializer;
+import org.apache.sis.metadata.sql.util.Initializer;
 import org.apache.sis.metadata.iso.extent.DefaultGeographicBoundingBox;
 import org.apache.sis.referencing.CRS;
 import org.apache.sis.referencing.CommonCRS;

--- a/godiva/src/main/java/uk/ac/rdg/resc/godiva/server/ConfigServlet.java
+++ b/godiva/src/main/java/uk/ac/rdg/resc/godiva/server/ConfigServlet.java
@@ -37,11 +37,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/graphics/src/main/java/uk/ac/rdg/resc/edal/graphics/style/ColouredGlyphLayer.java
+++ b/graphics/src/main/java/uk/ac/rdg/resc/edal/graphics/style/ColouredGlyphLayer.java
@@ -41,7 +41,7 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.imageio.ImageIO;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.Unmarshaller;
 
 import uk.ac.rdg.resc.edal.exceptions.EdalException;
 import uk.ac.rdg.resc.edal.feature.DiscreteFeature;

--- a/graphics/src/main/java/uk/ac/rdg/resc/edal/graphics/style/sld/StyleSLDParser.java
+++ b/graphics/src/main/java/uk/ac/rdg/resc/edal/graphics/style/sld/StyleSLDParser.java
@@ -9,7 +9,7 @@ import uk.ac.rdg.resc.edal.graphics.style.FlatOpacity;
 import uk.ac.rdg.resc.edal.graphics.style.ImageLayer;
 import uk.ac.rdg.resc.edal.graphics.style.MapImage;
 
-import javax.xml.bind.annotation.adapters.XmlAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;

--- a/graphics/src/main/java/uk/ac/rdg/resc/edal/graphics/utils/GraphicsUtils.java
+++ b/graphics/src/main/java/uk/ac/rdg/resc/edal/graphics/utils/GraphicsUtils.java
@@ -44,7 +44,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import javax.xml.bind.annotation.adapters.XmlAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 
 import org.joda.time.DateTime;
 import org.slf4j.Logger;

--- a/pom.xml
+++ b/pom.xml
@@ -228,17 +228,17 @@
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>2.3.2</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
-            <version>2.3.0</version>
+            <version>3.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-core</artifactId>
-            <version>2.3.0</version>
+            <version>3.0.2</version>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,12 @@
             <version>2.3.0</version>
         </dependency>
         <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>5.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.1</version>

--- a/wms/pom.xml
+++ b/wms/pom.xml
@@ -37,12 +37,6 @@
             <version>20160810</version>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>javax.transaction</groupId>
             <artifactId>javax.transaction-api</artifactId>
             <version>1.3</version>

--- a/wms/src/main/java/uk/ac/rdg/resc/edal/wms/RequestParams.java
+++ b/wms/src/main/java/uk/ac/rdg/resc/edal/wms/RequestParams.java
@@ -32,7 +32,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import uk.ac.rdg.resc.edal.exceptions.EdalException;
 

--- a/wms/src/main/java/uk/ac/rdg/resc/edal/wms/ScreenshotServlet.java
+++ b/wms/src/main/java/uk/ac/rdg/resc/edal/wms/ScreenshotServlet.java
@@ -47,10 +47,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.imageio.ImageIO;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/wms/src/main/java/uk/ac/rdg/resc/edal/wms/WmsContextListener.java
+++ b/wms/src/main/java/uk/ac/rdg/resc/edal/wms/WmsContextListener.java
@@ -33,8 +33,8 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Enumeration;
 
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/wms/src/main/java/uk/ac/rdg/resc/edal/wms/WmsServlet.java
+++ b/wms/src/main/java/uk/ac/rdg/resc/edal/wms/WmsServlet.java
@@ -55,12 +55,12 @@ import java.util.TreeSet;
 
 import javax.imageio.ImageIO;
 import javax.naming.OperationNotSupportedException;
-import javax.servlet.Servlet;
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.velocity.Template;

--- a/wms/src/main/java/uk/ac/rdg/resc/edal/wms/util/WmsUtils.java
+++ b/wms/src/main/java/uk/ac/rdg/resc/edal/wms/util/WmsUtils.java
@@ -39,8 +39,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.joda.time.Chronology;
 import org.joda.time.chrono.ISOChronology;

--- a/xml-catalogue/src/main/java/uk/ac/rdg/resc/edal/catalogue/jaxb/CacheInfo.java
+++ b/xml-catalogue/src/main/java/uk/ac/rdg/resc/edal/catalogue/jaxb/CacheInfo.java
@@ -28,11 +28,11 @@
 
 package uk.ac.rdg.resc.edal.catalogue.jaxb;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import uk.ac.rdg.resc.edal.graphics.utils.FeatureCatalogue;
 

--- a/xml-catalogue/src/main/java/uk/ac/rdg/resc/edal/catalogue/jaxb/CatalogueConfig.java
+++ b/xml-catalogue/src/main/java/uk/ac/rdg/resc/edal/catalogue/jaxb/CatalogueConfig.java
@@ -46,16 +46,16 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.SchemaOutputResolver;
-import javax.xml.bind.Unmarshaller;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.SchemaOutputResolver;
+import jakarta.xml.bind.Unmarshaller;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import javax.xml.transform.Result;
 import javax.xml.transform.stream.StreamResult;
 

--- a/xml-catalogue/src/main/java/uk/ac/rdg/resc/edal/catalogue/jaxb/DatasetConfig.java
+++ b/xml-catalogue/src/main/java/uk/ac/rdg/resc/edal/catalogue/jaxb/DatasetConfig.java
@@ -38,13 +38,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
 
 import org.joda.time.DateTime;
 import org.slf4j.Logger;

--- a/xml-catalogue/src/main/java/uk/ac/rdg/resc/edal/catalogue/jaxb/VariableConfig.java
+++ b/xml-catalogue/src/main/java/uk/ac/rdg/resc/edal/catalogue/jaxb/VariableConfig.java
@@ -32,13 +32,13 @@ import java.awt.Color;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.adapters.XmlAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import uk.ac.rdg.resc.edal.dataset.Dataset;
 import uk.ac.rdg.resc.edal.domain.Extent;

--- a/xml-catalogue/src/test/java/uk/ac/rdg/resc/edal/catalogue/jaxb/XmlDataCatalogueTest.java
+++ b/xml-catalogue/src/test/java/uk/ac/rdg/resc/edal/catalogue/jaxb/XmlDataCatalogueTest.java
@@ -32,7 +32,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 
 import uk.ac.rdg.resc.edal.catalogue.DataCatalogue;
 import uk.ac.rdg.resc.edal.dataset.Dataset;


### PR DESCRIPTION
As part of the updates needed for TDS to move to Spring 6/ Jakarta EE 9, this PR updates to:
- jakarta servlet API 5
- jakarta xml bind 3
Both of which require moves from Javax to jakarta namespace.

In addition, to be compatible with jakarta xml bind 3, the apache sis library is updated from 1.0 to 1.4. This required one change for an import of an internal package in `GISUtils.java`.